### PR TITLE
fix/issue-35/api-cannot-be-used-async

### DIFF
--- a/_dev/src/addons/XT/Membermap/_output/templates/_metadata.json
+++ b/_dev/src/addons/XT/Membermap/_output/templates/_metadata.json
@@ -85,9 +85,9 @@
         "hash": "6b5bfe60eaf66177e30a16bea5038171"
     },
     "public/xt_mm_index.html": {
-        "version_id": 1000471,
-        "version_string": "1.0.4.1",
-        "hash": "ea90c3dd63a5880c9a4b69d3d582610e"
+        "version_id": 1000570,
+        "version_string": "1.0.5",
+        "hash": "fbdf84a2183ca4755603bad445fb6feb"
     },
     "public/xt_mm_macros.html": {
         "version_id": 1000470,

--- a/_dev/src/addons/XT/Membermap/_output/templates/public/xt_mm_index.html
+++ b/_dev/src/addons/XT/Membermap/_output/templates/public/xt_mm_index.html
@@ -19,9 +19,9 @@
 <xf:css src="xt_mm.less" />
 <xf:css src="member_tooltip.less" />
 <xf:if is="$googleMapsId">
-	<xf:js src="https://maps.googleapis.com/maps/api/js?key={$googleJsApiKey}&loading=async&region={$region}&language={$language}&map_ids={$googleMapsId}" />
+	<xf:js src="https://maps.googleapis.com/maps/api/js?key={$googleJsApiKey}&region={$region}&language={$language}&map_ids={$googleMapsId}" />
 <xf:else />
-	<xf:js src="https://maps.googleapis.com/maps/api/js?key={$googleJsApiKey}&loading=async&region={$region}&language={$language}" />
+	<xf:js src="https://maps.googleapis.com/maps/api/js?key={$googleJsApiKey}&region={$region}&language={$language}" />
 </xf:if>
 <xf:js src="https://unpkg.com/@googlemaps/markerclustererplus/dist/index.min.js" />
 <xf:js addon="XT/Membermap" src="xt/membermap/map{{ $xf.versionId >= 2030000 ? '-xf23' : '' }}.js" min="0" />


### PR DESCRIPTION
Load Google Maps API synchronously. This is deprecated, but can't be fixed without breaking changes to the JavaScript code so this is not possible in 1.0 branch

Closes #35