### PR TITLE
fix/issue-39/sporadic-js-error-when-map-is-initialized

### DIFF
--- a/_dev/src/addons/XT/Membermap/_files/js/xt/membermap/map-xf23.js
+++ b/_dev/src/addons/XT/Membermap/_files/js/xt/membermap/map-xf23.js
@@ -133,10 +133,12 @@
 				});
 			}
 
-			this.oms = new OverlappingMarkerSpiderfier(this.map, {keepSpiderfied : true});
-			for (let i = 0, len = this.markers.length; i < len; i ++){
-				this.oms.addMarker(this.markers[i]);
-			}
+			google.maps.event.addListenerOnce(this.map, 'idle', () => {
+				this.oms = new OverlappingMarkerSpiderfier(this.map, {keepSpiderfied : true});
+				for (let i = 0, len = this.markers.length; i < len; i ++){
+					this.oms.addMarker(this.markers[i]);
+				}
+			});
 
 			if (this.bounds.getNorthEast().equals(this.bounds.getSouthWest())) {
 				const northEastLat = bounds.getNorthEast().lat()

--- a/_dev/src/addons/XT/Membermap/_files/js/xt/membermap/map.js
+++ b/_dev/src/addons/XT/Membermap/_files/js/xt/membermap/map.js
@@ -136,11 +136,13 @@
                 });
             }
 
-            this.oms = new OverlappingMarkerSpiderfier(this.map, {keepSpiderfied : true});
-            //for(var i = 0;i<=this.markers.length-1;i++)
-            for (var i = 0, len = this.markers.length; i < len; i ++){
-                this.oms.addMarker(this.markers[i]);
-            }
+            google.maps.event.addListenerOnce(this.map, 'idle', function () {
+                this.oms = new OverlappingMarkerSpiderfier(this.map, {keepSpiderfied : true});
+                //for(var i = 0;i<=this.markers.length-1;i++)
+                for (var i = 0, len = this.markers.length; i < len; i ++){
+                    this.oms.addMarker(this.markers[i]);
+                }
+            });
 
             if (this.bounds.getNorthEast().equals(this.bounds.getSouthWest())) {
                 var extendPoint1 = new google.maps.LatLng(this.bounds.getNorthEast().lat() + 0.01, this.bounds.getNorthEast().lng() + 0.01);


### PR DESCRIPTION
Load OMS when map is idle to prevent JS error
> Uncaught Must wait for 'idle' event on map before calling markersNearAnyOtherMarker

Closes #39